### PR TITLE
Updated reboot.js to implement full reboot functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Inside reboot.js edit the following two values.
 
 var routerAccessCode = "";  
 var routerIP = "192.168.1.254";  
+
+Additional code changes have been made to reference the THISPAGE & NEXTPAGE value as a variable called PAGE.
+
+For a broadband restart, the code can be easily be modified to change RESTART to RESET_BB, and change the value of the PAGE variable from C_5_7 back to A_0_0 if needed.

--- a/reboot.js
+++ b/reboot.js
@@ -1,21 +1,25 @@
 /* Fill in the access code and your router IP below */
-var routerAccessCode = "put_your_router_access_code_here";
+
+var routerAccessCode = "EnterRouterAccessCodeHere";
 var routerIP = "192.168.1.254";
+
 /****************************************************/
 
 var querystring = require('querystring');
 var request = require('request');
+var PAGE = 'C_5_7';
 
 function RebootRouter() {
 
     var form = {
-        "ADM_PASSWORD" : routerAccessCode,
-        "NEXTPAGE" : 'A_0_0'
+        "ADM_PASSWORD" : routerAccessCode
+        "NEXTPAGE" : PAGE
     };
 
     var formData = querystring.stringify(form);
     var contentLength = formData.length;
     var cookieJar = request.jar();
+
     request({
 
         headers: {
@@ -45,9 +49,7 @@ function RebootRouter() {
 function doRestart(cookieJar, nonce){
 
     var form = {
-        "RESET_BB" : 'Reset',
-        "THISPAGE" : 'A_0_0',
-        "NEXTPAGE" : 'A_0_0_POST',
+        "RESTART" : 'Reset',
         "NONCE": nonce,
         "CMSKICK": ""
     };
@@ -59,7 +61,7 @@ function doRestart(cookieJar, nonce){
             'Content-Length': contentLength,
             'Content-Type': 'application/x-www-form-urlencoded'
         },
-        uri: 'http://' + routerIP + '/xslt?PAGE=A_0_0_POST&NEXTPAGE=A_0_0_POST',
+        uri: 'http://' + routerIP + '/xslt?PAGE=' + PAGE + '_POST&NEXTPAGE=' + PAGE + '_POST',
         jar: cookieJar,
         body: formData,
         method: 'POST'


### PR DESCRIPTION
It looks like the current reboot.js does not fully restart the device, but instead resets the broadband connection; this PR is for updating the reboot.js logic to execute a full reboot

- Changed RESET_BB to RESTART, which now fully restarts the device
- For this function to work, I had to also change the value of THISPAGE & NEXTPAGE from A_0_0 to C_5_7
- I reference this value with the PAGE variable for easy modification in case it needs to be changed back